### PR TITLE
Added ability to use 'live' dust for mock Hubble Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/firestudio/ntbks/.ipynb_checkpoints/*
 *.sh
 Untitled*ipynb
 *.DS_Store
+.idea/

--- a/src/firestudio/studios/star_studio.py
+++ b/src/firestudio/studios/star_studio.py
@@ -14,6 +14,7 @@ from abg_python.galaxy.metadata_utils import metadata_cache
 from .studio import Studio
 
 from ..utils.stellar_utils import (
+    opacity_given_dust, ## calculate dust opacity using 'live' dust for arbitrary wavelengths
     opacity_per_solar_metallicity, ## calculate dust opacity for arbitrary wavelengths
     read_band_lums_from_tables, ## calculate luminosities in specific tabulated bands
     stellar_raytrace, ## project along the LoS and attenuate by obscuring dust column for 3 bands simultaneously
@@ -71,6 +72,9 @@ class StarStudio(Studio):
             of the image surface brightness, by default None
         nodust : bool
             flag for whether dust attenuantion should be ignored, by default False
+        live_dust : bool
+            flag for whether data includes 'live' dust to be used for dust attenuation. If not
+            then just assume a constant fraction of metals are in dust.
         age_max_gyr : float
             maximum age in Gyr to show stellar emission from. If None then emission from all star
             particles is considered, by default None
@@ -93,6 +97,8 @@ class StarStudio(Studio):
             'dynrange':None, ## controls the saturation of the image in a non-obvious way
             'color_scheme_nasa':True,
             'no_dust':False,
+            'live_dust': False, ## use 'live' dust from snapshot to determine dust attenuation
+            'force_dust_type': None, ## use to force dust type to SMC, LMC, or MW-type dust
             'age_max_gyr':None} ## flag to use nasa colors (vs. SDSS if false)
 
         for kwarg in list(kwargs.keys()):
@@ -128,6 +134,7 @@ class StarStudio(Studio):
         ## set any other image params here
         super().set_ImageParams(use_defaults=use_defaults,**kwargs)
         if self.no_dust: self.this_setup_id+='_no_dust'
+        if self.live_dust: self.this_setup_id+='_live_dust'
         if self.age_max_gyr is not None: self.this_setup_id+='_age_max%0.3f'%self.age_max_gyr
 
     append_function_docstring(set_ImageParams,Studio.set_ImageParams,prepend_string='passes `kwargs` to:\n')
@@ -140,6 +147,7 @@ class StarStudio(Studio):
             'dynrange' : 100.0, ## controls the saturation of the image in a non-obvious way
             'color_scheme_nasa' : True, ## flag to use nasa colors (vs. SDSS if false)
             'no_dust':False,
+            'live_dust':False, ## use 'live' dust from snapshot to determine dust attenuation
             'age_max_gyr':None} ## flag to use nasa colors (vs. SDSS if false)
 
         ## print the current value, not the default value
@@ -200,7 +208,7 @@ class StarStudio(Studio):
         # apply filters, rotations, unpack snapshot data, etc...
         (kappas, lums,
             star_pos, h_star,
-            gas_pos , mgas , gas_metals ,  h_gas) = self.prepareCoordinates(lums,nu_effs,BAND_IDS)
+            gas_pos , mgas , gas_weight , h_gas) = self.prepareCoordinates(lums,nu_effs,BAND_IDS)
 
         star_xs,star_ys,star_zs = star_pos.T
         gas_xs,gas_ys,gas_zs = gas_pos.T
@@ -214,10 +222,10 @@ class StarStudio(Studio):
 
         outs = np.zeros((3,xedges.size-1,yedges.size-1))
 
-        metal_mass_map,xedges,yedges = np.histogram2d(
+        weight_mass_map,xedges,yedges = np.histogram2d(
             gas_xs,gas_ys,
             bins=[xedges,yedges],
-            weights=mgas*gas_metals)
+            weights=mgas*gas_weight)
 
         for i,lum in enumerate(lums):
             outs[i],xedges,yedges = np.histogram2d(
@@ -225,11 +233,11 @@ class StarStudio(Studio):
                 bins=[xedges,yedges],
                 weights=lum)
         
-            outs[i]*=np.exp(-kappas[i]*metal_mass_map/dA*5)
+            outs[i]*=np.exp(-kappas[i]*weight_mass_map/dA*5)
 
         unit_factor = 1e10/self.Acell
 
-        return metal_mass_map*unit_factor,outs[0]*unit_factor,outs[1]*unit_factor,outs[2]*unit_factor
+        return weight_mass_map*unit_factor,outs[0]*unit_factor,outs[1]*unit_factor,outs[2]*unit_factor
 
     def get_mockHubbleImage(
         self,
@@ -290,16 +298,17 @@ class StarStudio(Studio):
             # apply filters, rotations, unpack snapshot data, etc...
             (kappas, lums,
                 star_pos, h_star,
-                gas_pos , mgas , gas_metals ,  h_gas) = self.prepareCoordinates(lums,nu_effs,BAND_IDS,fixed_star_hsml)
+                gas_pos , mgas , gas_weight ,  h_gas) = self.prepareCoordinates(lums,nu_effs,BAND_IDS,fixed_star_hsml)
 
             ## do the actual raytracing
             gas_out,out_u,out_g,out_r = raytrace_ugr_attenuation(
                 star_pos[:,0],star_pos[:,1],star_pos[:,2],
                 h_star,
                 gas_pos[:,0],gas_pos[:,1],gas_pos[:,2],
-                mgas,gas_metals,h_gas,
+                mgas,gas_weight,h_gas,
                 kappas,lums,
                 pixels=self.pixels,
+                live_dust=self.live_dust,
                 QUIET=not self.master_loud,
                 xlim = (self.Xmin, self.Xmax),
                 ylim = (self.Ymin, self.Ymax),
@@ -360,7 +369,7 @@ class StarStudio(Studio):
         np.ndarray(Ngas)
             mgas : mass data for attenuating gas in 10^10 Msun
         np.ndarray(Ngas)
-            gas_metals : total metal mass fraction for each gas particle
+            gas_weight : weights for attentuation, either total metal mass fraction or total dust mass fraction (if live dust) for each gas particle
         np.ndarray(Ngas)
             h_gas : smoothing length/radius for each gas particle in kpc
         """
@@ -393,7 +402,7 @@ class StarStudio(Studio):
                     Hsml = self.get_HSML('star',use_metadata=False,save_meta=True)
 
         ## attempt to pass these indices along
-        h_star = Hsml[star_mask].astype(np.float32)
+        h_star = Hsml.astype(np.float32)
 
         mstar = self.star_snapdict['Masses'][star_mask].astype(np.float32)
         metals = self.star_snapdict['Metallicity']
@@ -414,31 +423,35 @@ class StarStudio(Studio):
             lums=lums,
             QUIET=not self.master_loud)
 
-        ## calculate the kappa in this band using:
-        ##  Thompson scattering + 
-        ##  Pei (1992) + -- 304 < lambda[Angstroms] < 2e7
-        ##  Morrison & McCammon (1983) -- 1.2 < lambda[Angstroms] < 413
-        ## get opacities and luminosities at frequencies we need:
-
-        ## important to set KAPPA_UNITS appropriately: code loads opacity (kappa) for 
-        ##   the bands of interest in cgs (cm^2/g), must be converted to match units of input 
-        ##   mass and size. the default it to assume gadget units (M=10^10 M_sun, l=kpc)
-        KAPPA_UNITS=2.08854068444 ## cm^2/g -> kpc^2/mcode
-        kappas = [KAPPA_UNITS*opacity_per_solar_metallicity(nu_eff) for nu_eff in nu_effs]
-
         ## cull the particles outside the frame and cast to float32
         gas_pos,gas_mask = self.camera.project_and_clip(self.gas_snapdict['Coordinates'])
 
         if self.master_loud: print(np.sum(gas_mask),'many gas particles in volume')
 
         mgas = self.gas_snapdict['Masses'][gas_mask].astype(np.float32)
-        gas_metals = self.gas_snapdict['Metallicity']
-        if len(np.shape(gas_metals)) > 1: gas_metals = gas_metals[:,0]
-        gas_metals = gas_metals[gas_mask].astype(np.float32)
+        if self.live_dust:
+            print("Using live dust fields for Hubble image!")
+            if 'Flag_Dust' in self.gas_snapdict.keys():
+                gas_weight = self.gas_snapdict['DustMetallicity']
+                # Assume all C depleted onto dust is only in carbonaceous dust and all other depleted elements are in silicate dust
+                # That way it doesn't matter if you use the dust by species or dust by element dust routines
+                sil_frac = np.sum(self.gas_snapdict['DustMetallicity'][:,3:11],axis=1)
+                carb_frac = self.gas_snapdict['DustMetallicity'][:,2]
+                # Set sil-to-carb ratio to a arbitrarily large number when there is no carbonaceous dust
+                sc_ratios = np.where(carb_frac>0, sil_frac/carb_frac, 1E4)
+            else:
+                print("Wait, this snapshot doesn't have live dust! Will revert back to no live dust.")
+                self.live_dust = False
+                gas_weight = self.gas_snapdict['Metallicity']
+        else:
+            gas_weight = self.gas_snapdict['Metallicity']
+        if len(np.shape(gas_weight)) > 1: gas_weight = gas_weight[:,0]
+        gas_weight = gas_weight[gas_mask].astype(np.float32)
 
-        ## set metallicity of hot gas to 0 so there is no dust extinction
-        temperatures = self.gas_snapdict['Temperature'][gas_mask]
-        gas_metals[temperatures>1e5] = 0
+        if not self.live_dust:
+            ## set metallicity of hot gas to 0 so there is no dust extinction
+            temperatures = self.gas_snapdict['Temperature'][gas_mask]
+            gas_weight[temperatures>1e5] = 0
 
         if "SmoothingLength" not in self.gas_snapdict:
             h_gas = self.get_HSML('gas')[gas_mask]
@@ -448,12 +461,28 @@ class StarStudio(Studio):
         if self.no_dust: 
             mgas = np.zeros(1)
             gas_pos = np.zeros((1,3))
-            gas_metals = np.zeros(1)
+            gas_weight = np.zeros(1)
             h_gas = np.array([1e-3])
+
+       ## calculate the kappa in this band using:
+        ##  Thompson scattering +
+        ##  Pei (1992) + -- 304 < lambda[Angstroms] < 2e7
+        ##  Morrison & McCammon (1983) -- 1.2 < lambda[Angstroms] < 413
+        ## get opacities and luminosities at frequencies we need:
+
+        ## important to set KAPPA_UNITS appropriately: code loads opacity (kappa) for
+        ##   the bands of interest in cgs (cm^2/g), must be converted to match units of input
+        ##   mass and size. the default it to assume gadget units (M=10^10 M_sun, l=kpc)
+        KAPPA_UNITS=2.08854068444 ## cm^2/g -> kpc^2/mcode
+        if self.live_dust:
+            # Use the average silicate-to-carbonaceous dust ratio to automatically choose MW,LMC,or SMC-like dust for kappa
+            kappas = [KAPPA_UNITS*opacity_given_dust(nu_eff, sc_ratio=np.median(sc_ratios), force_dust_type=self.force_dust_type) for nu_eff in nu_effs]
+        else:
+            kappas = [KAPPA_UNITS*opacity_per_solar_metallicity(nu_eff, force_dust_type=self.force_dust_type) for nu_eff in nu_effs]
 
         return (kappas, lums,
                 star_pos, h_star,
-                gas_pos , mgas , gas_metals ,  h_gas)
+                gas_pos , mgas , gas_weight ,  h_gas)
 
 ####### produceImage implementation #######
     def produceImage(
@@ -711,11 +740,12 @@ def raytrace_ugr_attenuation(
     x,y,z,
     h_star, 
     gx,gy,gz,
-    mgas, gas_metals,
+    mgas, gas_weight,
     h_gas,
     kappas,lums,
     pixels = 1200,
     xlim = None, ylim = None, zlim = None,
+    live_dust=False,
     QUIET=False,
     ):
 
@@ -732,11 +762,12 @@ def raytrace_ugr_attenuation(
         x,y,z,
         h_star,
         gx,gy,gz,
-        mgas,gas_metals,
+        mgas,gas_weight,
         h_gas,
         kappas,lums,
         xlim=xlim,ylim=ylim,zlim=zlim,
         pixels=pixels,
+        live_dust=live_dust,
         QUIET=QUIET) 
 
 __doc__  = ''

--- a/src/firestudio/studios/star_studio.py
+++ b/src/firestudio/studios/star_studio.py
@@ -439,8 +439,8 @@ class StarStudio(Studio):
                 gas_weight = self.gas_snapdict['DustMetallicity']
                 # Assume all C depleted onto dust is only in carbonaceous dust and all other depleted elements are in silicate dust
                 # That way it doesn't matter if you use the dust by species or dust by element dust routines
-                sil_frac = np.sum(self.gas_snapdict['DustMetallicity'][:,3:11],axis=1)
-                carb_frac = self.gas_snapdict['DustMetallicity'][:,2]
+                sil_frac = np.sum(self.gas_snapdict['DustMetallicity'][:,3:11],axis=1)[gas_mask]
+                carb_frac = self.gas_snapdict['DustMetallicity'][:,2][gas_mask]
                 # Set sil-to-carb ratio to a arbitrarily large number when there is no carbonaceous dust
                 sc_ratios = np.where(carb_frac>0, sil_frac/carb_frac, 1E4)
             else:
@@ -452,9 +452,9 @@ class StarStudio(Studio):
         if len(np.shape(gas_weight)) > 1: gas_weight = gas_weight[:,0]
         gas_weight = gas_weight[gas_mask].astype(np.float32)
 
+        temperatures = self.gas_snapdict['Temperature'][gas_mask]
         if not self.live_dust:
             ## set metallicity of hot gas to 0 so there is no dust extinction
-            temperatures = self.gas_snapdict['Temperature'][gas_mask]
             gas_weight[temperatures>1e5] = 0
 
         if "SmoothingLength" not in self.gas_snapdict:

--- a/src/firestudio/utils/stellar_utils/__init__.py
+++ b/src/firestudio/utils/stellar_utils/__init__.py
@@ -1,5 +1,5 @@
 ## unify namespace for convenience
-from .cross_section import opacity_per_solar_metallicity
+from .cross_section import opacity_per_solar_metallicity,opacity_given_dust
 from .colors_sps.read_band_lums_from_tables import read_band_lums_from_tables
 from .raytrace_projection import stellar_raytrace,raytrace_projection_compute
 from .make_threeband_image import make_threeband_image_process_bandmaps,layer_band_images

--- a/src/firestudio/utils/stellar_utils/cross_section.py
+++ b/src/firestudio/utils/stellar_utils/cross_section.py
@@ -9,30 +9,33 @@ import numpy as np
 #		lambda = 0.001 micrometer (= 10 Angstroms, or f = 3.0e17 Hz), where 
 #		the extinction drops off rapidly. So it's probably safe to use for all freq.
 #-------------------------------------------------------------------------------------
-def pei_dustparam( lambda_microns, MW=0, LMC=0, SMC=1 ):
+def pei_dustparam( lambda_microns, dust_property='SMC'):
 
     ## see Table 4 of Pei92
-    if (MW==1):
+    if dust_property=='MW':
         ##  BKG    FUV   2175 A 9.7 um 18 um  FIR
         a = [165. , 14. , 0.045, 0.002, 0.002, 0.012]
         l = [0.047, 0.08, 0.22 , 9.7  , 18.  , 25.  ]
         b = [90.  , 4.00, -1.95, -1.95, -1.80, 0.00 ]
         n = [2.0  , 6.5 , 2.0  , 2.0  , 2.0  , 2.0  ]
         R_V = 3.08 ## Table 2
-    if (LMC==1):
+    elif dust_property=='LMC':
         ##  BKG    FUV   2175 A 9.7 um 18 um  FIR
         a = [175. , 19. , 0.023, 0.005, 0.006, 0.020]
         l = [0.046, 0.08, 0.22 , 9.7  , 18.  , 25.  ]
         b = [90.  , 5.50, -1.95, -1.95, -1.80, 0.00 ]
         n = [2.0  , 4.5 , 2.0  , 2.0  , 2.0  , 2.0  ]
         R_V = 3.16 ## Table 2
-    if (SMC==1):
+    elif dust_property=='SMC':
         ##  BKG    FUV   2175 A 9.7 um 18 um  FIR
         a = [185. , 27. , 0.005, 0.010, 0.012, 0.030]
         l = [0.042, 0.08, 0.22 , 9.7  , 18.  , 25.  ]
         b = [90.  , 5.50, -1.95, -1.95, -1.80, 0.00 ]
         n = [2.0  , 4.0 , 2.0  , 2.0  , 2.0  , 2.0  ]
         R_V = 2.93 ## Table 2
+    else:
+        print("%s is not a valid dust type for dust extinction. Must be SMC, LMC, or MW."%dust_type)
+        a = [0]; l = [0]; b = [0];  n = [0]; R_V = 0
 
     xsi = 0.*lambda_microns;
     for i in range(len(a)):
@@ -101,7 +104,7 @@ def morrison_photoelec( frequency ):
 # Function to calculate the cross section per H atom at a given 
 #    frequency f (in Hz)
 #--------------------------------------------------------------------------
-def cross_section( f0, METALLICITY_OVER_SOLAR=1.0 ):
+def cross_section( f0, METALLICITY_OVER_SOLAR=1., dg_ratio:np.ndarray=None, sc_ratio:np.ndarray=None, force_dust_type:str=None):
     f0=np.array(f0);
     SIGMA = 0.0*np.array(f0);
 
@@ -111,6 +114,9 @@ def cross_section( f0, METALLICITY_OVER_SOLAR=1.0 ):
     #   Morrison & McCammon (1983)
     #     NOTE: these assume solar abundances and no ionization, 
     #             the appropriate number probably scales linearly with both
+    #           also do not include the effects of dust in their final fit
+    #              but the effects should be neglibible even if you assume almost all elements
+    #              depleted onto dust
     #   (this is all for the COMPTON THIN regime)
     #
     f_003keV = 7.253e15
@@ -128,30 +134,71 @@ def cross_section( f0, METALLICITY_OVER_SOLAR=1.0 ):
     # For optical-IR regions, we use the Pei numerical approximations below.
     #
     # xsi = tau(lambda)/tau(B) is the ratio of extinction at lambda to the 
-    #    extinction in the B-band. 
+    #    extinction in the B-band and depends on the grain properties
     # k = 10^21 (tau_B / NH)   (NH in cm^2) gives the dimensionless gas-to-dust
     #    ratio, with k=0.78 for MW, k=0.16 for LMC, k=0.08 for SMC.
-    #    k is INDEPENDENT of the grain properties, and seems to scale rougly
+    #    k is INDEPENDENT of the grain properties, and seems to scale roughly
     #    linearly with metallicity
-    # so, for now, assume solar metallicity and k = k_MW = 0.78. we can rescale later.
+    #    so, for now, assume solar metallicity and k = k_MW = 0.78. we can rescale later.
     #
     # tau_B = ( NH / (10^21 cm^-2) ) * k --> SIGMA_B = k*10^-21  cm^2
     # tau_lambda = xsi * tau_B --> SIGMA = xsi * SIGMA_B
     #
     # k = 0.78 for the MW
+    # k = 0.16 for the LMC
     # k = 0.08 for the SMC, approximately in line with the MW/LMC/SMC metallicity 
     #  sequence, so we take a k_MW then scaled by the metallicity
-    #
-    k = 0.78 * METALLICITY_OVER_SOLAR
+    # If provided use tracked dust-to-gas (D/G) ratio instead of assuming MW value,
+    #  the k value in Pei92 assumes Z_solar ~ 0.02 which corresponds to a D/G~0.0075,D/Z~0.4 so we can scale in relation to this
+    if dg_ratio is not None:
+        k = 0.78 * dg_ratio/0.0075
+    else:
+        k = 0.78 * METALLICITY_OVER_SOLAR
     if (SIGMA.size > 1):
         ok=(f0 < f_003keV)
         lambda_microns = 2.998e14 / f0[ok];   # convert frequency [Hz] to wavelength [microns]
-        xsi = pei_dustparam( lambda_microns, SMC=1 );
+        if sc_ratio is not None and force_dust_type is None:
+            # Determine the global silicate-to-carbonaceous dust ratio and use that to estimate
+            # whether the dust is MW, LMC, or SMC
+            # SMC is mostly silicate dust so assume anything with less than 5% carbon dust
+            if sc_ratio >= 20:
+                dust_property = 'SMC'
+            # LMC has some carbon dust ~1:4 ratio
+            elif sc_ratio < 20 and sc_ratio > 3.5:
+                dust_property = 'LMC'
+            # MW has a large amount of carbon dust ~1:2 ratio
+            else:
+                dust_property = 'MW'
+            print("Si/C ratio is :",sc_ratio)
+            print("Will be using %s-type dust for extinction..."%dust_property)
+            xsi = pei_dustparam( lambda_microns, dust_property=dust_property );
+        elif force_dust_type is not None:
+            print('Using %s-type dust for extinction...'%force_dust_type)
+            xsi = pei_dustparam( lambda_microns, dust_property=force_dust_type );
+        else:
+            xsi = pei_dustparam( lambda_microns, dust_property='SMC' );
         SIGMA[ok] += xsi * k * 1.0e-21;
     else:
         if (f0 < f_003keV):
             lambda_microns = 2.998e14 / f0;   # convert frequency [Hz] to wavelength [microns]
-            xsi = pei_dustparam( lambda_microns, SMC=1 );
+            if sc_ratio is not None and force_dust_type is None:
+                # SMC is near entirely silicate dust so assume anything with less than 5% carbon dust
+                if sc_ratio >= 20:
+                    dust_property = 'SMC'
+                # LMC has some carbon dust ~1:4 ratio
+                elif sc_ratio < 20 and sc_ratio > 3.5:
+                    dust_property = 'LMC'
+                # MW has a large amount of carbon dust ~1:2 ratio
+                else:
+                    dust_property = 'MW'
+                print("Si/C ratio is :",sc_ratio)
+                print("Will be using %s-type dust for extinction..."%dust_property)
+                xsi = pei_dustparam( lambda_microns, dust_property=dust_property );
+            elif force_dust_type is not None:
+                print('Using %s-type dust for extinction...'%force_dust_type)
+                xsi = pei_dustparam( lambda_microns, dust_property=force_dust_type );
+            else:
+                xsi = pei_dustparam( lambda_microns, dust_property='SMC' );
             SIGMA += xsi * k * 1.0e-21;
 
     # No double-counting, but I have checked it in detail, and there is really almost
@@ -171,7 +218,16 @@ def cross_section( f0, METALLICITY_OVER_SOLAR=1.0 ):
 
 
 ## simple routine for opacity scaled to solar metallicity at frequencies f0
-def opacity_per_solar_metallicity( f0 ):
+def opacity_per_solar_metallicity( f0, force_dust_type:str=None ):
     mu = 0.75 ## assume dense gas
-    return cross_section( f0, METALLICITY_OVER_SOLAR=1.0 ) / ( mu * 1.67e-24 );
+    return cross_section( f0, METALLICITY_OVER_SOLAR=1.0, force_dust_type=force_dust_type ) / ( mu * 1.67e-24 );
+
+## more complex routine for opacity frequencies f0 given each gas parcel's dust-to-gas ratio and/or
+## galaxy average silicate-to-carbonaceous dust ratio.
+## Uses the same Pei92 extinction model, but scales with local dust-to-gas ratio and chooses MW, LMC, or SMC
+## depending on the local silicate-to-carbonaceous dust ratio. MW has the most carbonaceous dust while SMC
+## has almost no carbonaceous dust.
+def opacity_given_dust( f0, dg_ratio:float=None, sc_ratio:float=None, force_dust_type:str=None ):
+    mu = 0.75 ## assume dense gas
+    return cross_section( f0, dg_ratio=dg_ratio, sc_ratio=sc_ratio, force_dust_type=force_dust_type ) / ( mu * 1.67e-24 );
     

--- a/src/firestudio/utils/stellar_utils/cross_section.py
+++ b/src/firestudio/utils/stellar_utils/cross_section.py
@@ -104,7 +104,7 @@ def morrison_photoelec( frequency ):
 # Function to calculate the cross section per H atom at a given 
 #    frequency f (in Hz)
 #--------------------------------------------------------------------------
-def cross_section( f0, METALLICITY_OVER_SOLAR=1., dg_ratio:np.ndarray=None, sc_ratio:np.ndarray=None, force_dust_type:str=None):
+def cross_section( f0, METALLICITY_OVER_SOLAR=1., dg_ratio:np.ndarray=None, sc_ratio:float=None, force_dust_type:str=None):
     f0=np.array(f0);
     SIGMA = 0.0*np.array(f0);
 

--- a/src/firestudio/utils/stellar_utils/load_stellar_hsml.py
+++ b/src/firestudio/utils/stellar_utils/load_stellar_hsml.py
@@ -24,7 +24,7 @@ def get_particle_hsml( x, y, z, DesNgb=32, Hmax=0.):
             np.max(y)-np.min(y),
             np.max(z)-np.min(z)]) 
 
-        Hmax=5.*max_dx*(np.float(num_points)**(-1./3.)) ## mean inter-particle spacing
+        Hmax=5.*max_dx*(np.float64(num_points)**(-1./3.)) ## mean inter-particle spacing
 
     ## load the routine we need
     ## find the path of the parent directory, removing any symbolic links for safety

--- a/src/firestudio/utils/stellar_utils/make_threeband_image.py
+++ b/src/firestudio/utils/stellar_utils/make_threeband_image.py
@@ -3,7 +3,7 @@ import matplotlib
 
 def checklen(x): return np.array(x).shape[0]
 
-def int_round(x): return np.int(np.round(x))
+def int_round(x): return np.int64(np.round(x))
 
 def ok_scan(arr,xmax=1.0e10,pos=0):
     if (pos==0): return np.logical_and(
@@ -83,7 +83,7 @@ def make_threeband_image_process_bandmaps(
 
     f_saturated=0.0004  ## fraction of pixels that should be saturated
     f_saturated=0.0001  ## fraction of pixels that should be saturated
-    x0 = int_round( f_saturated * (np.float(checklen(r)) - 1.) )
+    x0 = int_round( f_saturated * (np.float64(checklen(r)) - 1.) )
 
     for rgb_v in [r,g,b]: 
         rgbm = single_vec_sorted(rgb_v,reverse=True)

--- a/src/firestudio/utils/stellar_utils/raytrace_projection.py
+++ b/src/firestudio/utils/stellar_utils/raytrace_projection.py
@@ -4,7 +4,7 @@ import ctypes
 
 def checklen(x): return np.array(x,ndmin=1).shape[0]
 
-def int_round(x): return np.int(np.round(x))
+def int_round(x): return np.int64(np.round(x))
 
 def ok_scan(arr,xmax=1.0e30,pos=0):
     if (pos==0): return np.logical_and(
@@ -125,7 +125,7 @@ def raytrace_projection_compute(
     ## determine shape of output
     aspect_ratio = ylen/xlen
     Xpixels = int_round(pixels)
-    Ypixels = int_round(aspect_ratio*np.float(Xpixels))
+    Ypixels = int_round(aspect_ratio*np.float32(Xpixels))
     N_pixels = Xpixels*Ypixels
 
     if (TRIM_PARTICLES==1): tolfac = 0.05


### PR DESCRIPTION
Added ability to use tracked dust properties for snapshots with 'live' dust when making mock Hubble visualizations.
Routine will use the global silicate-to-carbonaceous dust ratio to determine whether the dust population is SMC, LMC, or MW or user can just force which dust population to use.
Routine will also determine each gas parcel's effective attenuation mass by using local gas-to-dust ratios instead of always assuming a MW dust-to-metal ratio with some gas temperature cutoff.